### PR TITLE
Move to server 5

### DIFF
--- a/src/firestore/app/appkit.ts
+++ b/src/firestore/app/appkit.ts
@@ -160,37 +160,6 @@ export class RoarAppkit {
   }
 
   /**
-   * Validate the task variant parameters against a given JSON schema.
-   *
-   * This method uses the AJV library to validate the `variantParams` from the task information
-   * against the provided JSON schema. If the parameters are invalid, it throws an error with
-   * detailed messages for each validation error.
-   *
-   * @param {JSONSchemaType<unknown>} parameterSchema - The JSON schema to validate the parameters against.
-   * @throws {Error} Throws an error if the parameters are invalid, including detailed validation error messages.
-   */
-  async validateParameters(parameterSchema: JSONSchemaType<unknown>) {
-    // This version of ajv is not compatible with other JSON schema versions.
-    const ajv = new Ajv2020({ allErrors: true, verbose: true });
-    ajvErrors(ajv);
-
-    const validate = ajv.compile(parameterSchema);
-    const variantParams = this._taskInfo.variantParams;
-    const valid = validate(variantParams);
-
-    if (!valid) {
-      const errorMessages = validate.errors
-        ?.map((error) => {
-          return `Error in parameter "${error.instancePath}": ${error.message}`;
-        })
-        .join('\n');
-      throw new Error(`Detected invalid game parameters. \n\n${errorMessages}`);
-    } else {
-      console.log('Parameters successfully validated.');
-    }
-  }
-
-  /**
    * Update the ROAR task's game parameters.
    * This must be called after the startRun() method.
    *

--- a/src/firestore/app/appkit.ts
+++ b/src/firestore/app/appkit.ts
@@ -7,8 +7,6 @@ import { TaskVariantForAssessment, RoarTaskVariant } from './task';
 import { UserInfo, UserUpdateInput, RoarAppUser } from './user';
 import { FirebaseProject, OrgLists } from '../../interfaces';
 import { FirebaseConfig, initializeFirebaseProject } from '../util';
-import Ajv2020, { JSONSchemaType } from 'ajv/dist/2020';
-import ajvErrors from 'ajv-errors';
 
 
 export interface AppkitInput {
@@ -138,7 +136,7 @@ export class RoarAppkit {
       throw new Error('User must be authenticated to update their own data.');
     }
 
-    return this.user!.updateUser({ tasks, variants, assessmentPid, ...userMetadata });
+    return await this.user!.updateUser({ tasks, variants, assessmentPid, ...userMetadata });
   }
 
   /**
@@ -156,7 +154,7 @@ export class RoarAppkit {
       throw new Error('User must be authenticated to start a run.');
     }
 
-    return this.run!.startRun(additionalRunMetadata).then(() => (this._started = true));
+    return await this.run!.startRun(additionalRunMetadata).then(() => (this._started = true));
   }
 
   /**
@@ -169,7 +167,7 @@ export class RoarAppkit {
   async updateTaskParams(newParams: { [key: string]: unknown }) {
     if (this._started) {
       const oldVariantId = this.task!.variantId;
-      return this.task!.updateTaskParams(newParams)
+      return await this.task!.updateTaskParams(newParams)
         .then(() => {
           return updateDoc(this.user!.userRef, { variants: arrayRemove(oldVariantId) });
         })
@@ -197,7 +195,7 @@ export class RoarAppkit {
    */
   async updateEngagementFlags(flagNames: string[], markAsReliable = false, reliableByBlock = undefined) {
     if (this._started) {
-      return this.run!.addEngagementFlags(flagNames, markAsReliable, reliableByBlock);
+      return await this.run!.addEngagementFlags(flagNames, markAsReliable, reliableByBlock);
     } else {
       throw new Error('This run has not started. Use the startRun method first.');
     }
@@ -223,7 +221,7 @@ export class RoarAppkit {
    */
   async finishRun(finishingMetaData: { [key: string]: unknown } = {}) {
     if (this._started) {
-      return this.run!.finishRun(finishingMetaData);
+      return await this.run!.finishRun(finishingMetaData);
     } else {
       throw new Error('This run has not started. Use the startRun method first.');
     }
@@ -304,7 +302,7 @@ export class RoarAppkit {
     computedScoreCallback?: (rawScores: RawScores) => Promise<ComputedScores>,
   ) {
     if (this._started) {
-      return this.run!.writeTrial(trialData, computedScoreCallback);
+      return await this.run!.writeTrial(trialData, computedScoreCallback);
     } else {
       throw new Error('This run has not started. Use the startRun method first.');
     }

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -278,11 +278,11 @@ export class RoarRun {
     if (!this.aborted) {
       // In cases that the run is non-block-scoped and should only have the reliable attribute stored
       if (reliableByBlock === undefined) {
-        return updateDoc(this.runRef, { engagementFlags: engagementObj, reliable: markAsReliable });
+        return await updateDoc(this.runRef, { engagementFlags: engagementObj, reliable: markAsReliable });
       }
       // In cases we want to store reliability by block, we need to store the reliable attribute as well as the reliableByBlock attribute
       else {
-        return updateDoc(this.runRef, {
+        return await updateDoc(this.runRef, {
           engagementFlags: engagementObj,
           reliable: markAsReliable,
           reliableByBlock: reliableByBlock,
@@ -313,7 +313,7 @@ export class RoarRun {
         timeFinished: serverTimestamp(),
       };
 
-      return updateDoc(this.runRef, finishingData)
+      return await updateDoc(this.runRef, finishingData)
         .then(() => this.user.updateFirestoreTimestamp())
         .then(() => (this.completed = true));
     }

--- a/src/firestore/app/task.ts
+++ b/src/firestore/app/task.ts
@@ -143,7 +143,18 @@ export class RoarTaskVariant {
       lastUpdated: serverTimestamp(),
     };
 
-    await setDoc(this.taskRef, removeUndefined(taskData), { merge: true });
+    try {
+      await setDoc(this.taskRef, removeUndefined(taskData), { merge: true });
+    } catch (error) {
+      console.error('RoarTaskVariant toFirestore: error saving task to firestore', {
+        error,
+        errorMessage: error instanceof Error ? error.message : String(error),
+        errorCode: (error as any)?.code,
+        taskId: this.taskId,
+        taskRefPath: this.taskRef?.path,
+      });
+      throw error;
+    }
 
     // Check to see if variant exists already by querying for a match on the params.
     const q = query(

--- a/src/firestore/app/user.ts
+++ b/src/firestore/app/user.ts
@@ -131,34 +131,36 @@ export class RoarAppUser {
   }
 
   async init() {
-    return getDoc(this.userRef).then((docSnap) => {
-      this.onFirestore = docSnap.exists();
-      if (this.onFirestore) {
-        // If so, retrieve their data.
-        this.userData = docSnap.data();
-      } else {
-        // Otherwise allow them to create their own data ONLY if they are a guest.
-        this._setUserData();
-      }
-    });
+    const docSnap = await getDoc(this.userRef);
+    this.onFirestore = docSnap.exists();
+
+    if (this.onFirestore) {
+      // If so, retrieve their data.
+      this.userData = docSnap.data();
+    } else {
+      // Otherwise allow them to create their own data ONLY if they are a guest.
+      await this._setUserData();
+    }
   }
 
   private async _setUserData() {
     if (this.userType !== UserType.guest) {
       throw new Error('Cannot set user data on a non-guest ROAR user.');
     }
+
     this.userData = removeUndefined({
       ...this.userMetadata,
       assessmentPid: this.assessmentPid,
       assessmentUid: this.assessmentUid,
       userType: this.userType,
     });
-    return setDoc(this.userRef, {
+
+    await setDoc(this.userRef, {
       ...this.userData,
       created: serverTimestamp(),
-    }).then(() => {
-      this.onFirestore = true;
     });
+
+    this.onFirestore = true;
   }
 
   async checkUserExists() {
@@ -206,7 +208,7 @@ export class RoarAppUser {
       assessmentPid,
     });
 
-    return updateDoc(this.userRef, removeUndefined(userData));
+    return await updateDoc(this.userRef, removeUndefined(userData));
   }
 
   /**

--- a/src/firestore/app/user.ts
+++ b/src/firestore/app/user.ts
@@ -152,14 +152,6 @@ export class RoarAppUser {
       assessmentPid: this.assessmentPid,
       assessmentUid: this.assessmentUid,
       userType: this.userType,
-      // Use conditional spreading to add the testData flag only if it exists on
-      // the userDoc and is true.
-      // Explaination: We use the && operator to return the object only when
-      // condition is true. If the object is returned then it will be spread
-      // into runData.
-      ...(this.testData && { testData: true }),
-      // Same for demoData
-      ...(this.demoData && { demoData: true }),
     });
     return setDoc(this.userRef, {
       ...this.userData,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,11 +26,9 @@ type Grade = number | 'K' | 'PK' | 'TK';
 
 export enum UserType {
   admin = 'admin',
-  educator = 'educator',
+  super_admin = 'super_admin',
   student = 'student',
-  caregiver = 'caregiver',
   guest = 'guest',
-  researcher = 'researcher',
 }
 
 export interface ExtraMetadata extends DocumentData {
@@ -240,3 +238,17 @@ export type RoarOrg = District | School | Class | Family | Group;
 
 export type OrgType = 'district' | 'school' | 'class' | 'family' | 'group';
 export type OrgCollectionName = 'districts' | 'schools' | 'classes' | 'families' | 'groups';
+
+export interface StartTaskResult {
+  success: boolean;
+  taskInfo: {
+    taskName: string;
+    variantName: string;
+    variantParams: { [x: string]: unknown };
+    variantId: string;
+  };
+  assigningOrgs: OrgLists;
+  readOrgs: OrgLists;
+  userData: UserDataInAdminDb;
+  assessmentPid: string;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -242,7 +242,6 @@ export type OrgCollectionName = 'districts' | 'schools' | 'classes' | 'families'
 export interface StartTaskResult {
   success: boolean;
   taskInfo: {
-    taskName: string;
     variantName: string;
     variantParams: { [x: string]: unknown };
     variantId: string;


### PR DESCRIPTION
## Proposed changes
- Moving startAssessment and it's helper functions to the server
- Removing remaining helper functions that were used for starting and completing a task that are now on the server. 
- Other miscellaneous changes

With this change, we are now at exactly 1534 lines of code in Firekit. The first thousand or so are TypeScript interfaces, imports, class definition stuff, and authentication methods. The remaining 500 are all business logic stuff that is now just wrappers for the server calls. 

From here on, it's just looking at the ROAR app kit code, which itself is four distinct classes that are all used to run the tasks. 

<!--
Describe your changes here.

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
