### PR TITLE
FIX: Missing run + trial data

### DIFF
--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -19,7 +19,7 @@ import dot from 'dot-object';
 import { RoarTaskVariant } from './task';
 import { RoarAppUser } from './user';
 import { OrgLists } from '../../interfaces';
-import { removeUndefined } from '../util';
+import { removeUndefined, retryOperation } from '../util';
 import { FirebaseError } from '@firebase/util';
 
 /**
@@ -249,7 +249,10 @@ export class RoarRun {
       lastUpdated: serverTimestamp(),
     });
 
-    await batch.commit();
+    await retryOperation(
+      () => batch.commit(),
+      { operationName: 'startRun batch commit' }
+    );
 
     this.started = true;
   }

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -9,6 +9,7 @@ import {
   serverTimestamp,
   setDoc,
   updateDoc,
+  writeBatch,
 } from 'firebase/firestore';
 import _intersection from 'lodash/intersection';
 import _mapValues from 'lodash/mapValues';
@@ -240,14 +241,15 @@ export class RoarRun {
       ...(this.demoData && { demoData: true }),
     };
 
-    await setDoc(this.runRef, removeUndefined(runData))
-      .then(() => {
-        return updateDoc(this.user.userRef, {
-          tasks: arrayUnion(this.task.taskId),
-          variants: arrayUnion(this.task.variantId),
-        });
-      })
-      .then(() => this.user.updateFirestoreTimestamp());
+    const batch = writeBatch(this.user.db);
+    batch.set(this.runRef, removeUndefined(runData));
+    batch.update(this.user.userRef, {
+      tasks: arrayUnion(this.task.taskId),
+      variants: arrayUnion(this.task.variantId),
+      lastUpdated: serverTimestamp(),
+    });
+
+    await batch.commit();
 
     this.started = true;
   }
@@ -314,7 +316,6 @@ export class RoarRun {
       };
 
       return await updateDoc(this.runRef, finishingData)
-        .then(() => this.user.updateFirestoreTimestamp())
         .then(() => (this.completed = true));
     }
   }
@@ -344,165 +345,183 @@ export class RoarRun {
     if (!this.started) {
       throw new Error('Run has not been started yet. Use the startRun method first.');
     }
-    if (!this.aborted) {
-      // Check that the trial has all of the required reserved keys
-      if (
-        !requiredTrialFields.every((key) => {
-          return key in trialData && trialData[key] != undefined;
-        })
-      ) {
+
+    if (this.aborted) {
+      return;
+    }
+
+    // Check that the trial has all of the required reserved keys
+    if (
+      !requiredTrialFields.every((key) => {
+        return key in trialData && trialData[key] != undefined;
+      })
+    ) {
+      throw new Error(
+        'All ROAR trials saved to Firestore must have the following reserved keys: ' +
+          `${requiredTrialFields}.` +
+          'The current trial is missing the following required keys: ' +
+          `${requiredTrialFields.filter((key) => !(key in trialData))}.`,
+      );
+    }
+
+    const trialRef = doc(collection(this.runRef, 'trials'));
+    const trialDoc = {
+      ...convertTrialToFirestore(trialData),
+      taskId: this.task.taskId,
+      ...(this.testData && { testData: true }),
+      ...(this.demoData && { demoData: true }),
+      serverTimestamp: serverTimestamp(),
+      createdAt: serverTimestamp(),
+      // Trial documents are never updated, but for standardization, adding this field.
+      updatedAt: serverTimestamp(),
+    };
+
+    // Only update scores if the trial was a test or a practice response.
+    const shouldUpdateScores =
+      trialData.assessment_stage === 'test_response' || trialData.assessment_stage === 'practice_response';
+
+    if (!shouldUpdateScores) {
+      // Just write the trial, no score updates needed
+      await setDoc(trialRef, trialDoc);
+      return;
+    }
+
+    // Here we update the scores for this run. We create scores for each subtask in the task.
+    // E.g., ROAR-PA has three subtasks: FSM, LSM, and DEL. Each subtask has its own score.
+    // Conversely, ROAR-SWR has no subtasks. It's scores are stored in the 'composite' score field.
+    // If no subtask is specified, the scores for the 'composite' subtask will be updated.
+    const defaultSubtask = 'composite';
+    const subtask = (trialData.subtask || defaultSubtask) as string;
+    const stage = (trialData.assessment_stage as string).split('_')[0] as 'test' | 'practice';
+    const isCorrect = Boolean(trialData.correct);
+
+    // Extract theta values
+    const thetaEstimate = castToTheta(trialData.thetaEstimate as ThetaValue);
+    const thetaSE = castToTheta(trialData.thetaSE as ThetaValue);
+
+    // Helper function to update composite scores
+    const updateCompositeScores = (isInitializing: boolean) => {
+      if (subtask === defaultSubtask) return {};
+
+      if (isInitializing) {
+        _set(this.scores.raw, [defaultSubtask, stage], {
+          numAttempted: 1,
+          numCorrect: isCorrect ? 1 : 0,
+          numIncorrect: isCorrect ? 0 : 1,
+          thetaEstimate: null,
+          thetaSE: null,
+        });
+
+        return {
+          [`scores.raw.${defaultSubtask}.${stage}.numAttempted`]: 1,
+          [`scores.raw.${defaultSubtask}.${stage}.numCorrect`]: isCorrect ? 1 : 0,
+          [`scores.raw.${defaultSubtask}.${stage}.numIncorrect`]: isCorrect ? 0 : 1,
+          [`scores.raw.${defaultSubtask}.${stage}.thetaEstimate`]: null,
+          [`scores.raw.${defaultSubtask}.${stage}.thetaSE`]: null,
+        };
+      } else {
+        this.scores.raw[defaultSubtask][stage] = {
+          numAttempted: (this.scores.raw[defaultSubtask][stage]?.numAttempted || 0) + 1,
+          numCorrect: (this.scores.raw[defaultSubtask][stage]?.numCorrect || 0) + +isCorrect,
+          numIncorrect: (this.scores.raw[defaultSubtask][stage]?.numIncorrect || 0) + +!isCorrect,
+          thetaEstimate: null,
+          thetaSE: null,
+        };
+
+        return {
+          [`scores.raw.${defaultSubtask}.${stage}.numAttempted`]: increment(1),
+          [`scores.raw.${defaultSubtask}.${stage}.numCorrect`]: isCorrect ? increment(1) : undefined,
+          [`scores.raw.${defaultSubtask}.${stage}.numIncorrect`]: isCorrect ? undefined : increment(1),
+        };
+      }
+    };
+
+    let scoreUpdate: ScoreUpdate = {};
+
+    if (subtask in this.scores.raw) {
+      // Then this subtask has already been added to this run.
+      // Simply update the block's scores.
+      this.scores.raw[subtask][stage] = {
+        thetaEstimate,
+        thetaSE,
+        numAttempted: (this.scores.raw[subtask][stage]?.numAttempted || 0) + 1,
+        numCorrect: (this.scores.raw[subtask][stage]?.numCorrect || 0) + +isCorrect,
+        numIncorrect: (this.scores.raw[subtask][stage]?.numIncorrect || 0) + +!isCorrect,
+      };
+
+      // Populate the score update for Firestore.
+      scoreUpdate = {
+        [`scores.raw.${subtask}.${stage}.thetaEstimate`]: thetaEstimate,
+        [`scores.raw.${subtask}.${stage}.thetaSE`]: thetaSE,
+        [`scores.raw.${subtask}.${stage}.numAttempted`]: increment(1),
+        [`scores.raw.${subtask}.${stage}.numCorrect`]: isCorrect ? increment(1) : undefined,
+        [`scores.raw.${subtask}.${stage}.numIncorrect`]: isCorrect ? undefined : increment(1),
+        ...updateCompositeScores(false),
+      };
+    } else {
+      // This is the first time this subtask has been added to this run.
+      // Initialize the subtask scores.
+      _set(this.scores.raw, [subtask, stage], {
+        thetaEstimate,
+        thetaSE,
+        numAttempted: 1,
+        numCorrect: isCorrect ? 1 : 0,
+        numIncorrect: isCorrect ? 0 : 1,
+      });
+
+      // Populate the score update for Firestore.
+      scoreUpdate = {
+        [`scores.raw.${subtask}.${stage}.thetaEstimate`]: thetaEstimate,
+        [`scores.raw.${subtask}.${stage}.thetaSE`]: thetaSE,
+        [`scores.raw.${subtask}.${stage}.numAttempted`]: 1,
+        [`scores.raw.${subtask}.${stage}.numCorrect`]: isCorrect ? 1 : 0,
+        [`scores.raw.${subtask}.${stage}.numIncorrect`]: isCorrect ? 0 : 1,
+        ...updateCompositeScores(true),
+      };
+    }
+
+    if (computedScoreCallback) {
+      // Use the user-provided callback to compute the computed scores.
+      this.scores.computed = await computedScoreCallback(this.scores.raw);
+    } else {
+      // If no computedScoreCallback is provided, we default to
+      // numCorrect - numIncorrect for each subtask.
+      this.scores.computed = _mapValues(this.scores.raw, (subtaskScores) => {
+        const numCorrect = subtaskScores.test?.numCorrect || 0;
+        const numIncorrect = subtaskScores.test?.numIncorrect || 0;
+        return numCorrect - numIncorrect;
+      });
+    }
+
+    // Use dot-object to convert the computed scores into dotted-key/value pairs.
+    const fullUpdatePath = {
+      scores: {
+        computed: this.scores.computed,
+      },
+    };
+    scoreUpdate = {
+      ...scoreUpdate,
+      ...dot.dot(fullUpdatePath),
+    };
+
+    const batch = writeBatch(this.user.db);
+    batch.set(trialRef, trialDoc);
+    batch.update(this.runRef, removeUndefined(scoreUpdate));
+    batch.update(this.user.userRef, { lastUpdated: serverTimestamp() });
+
+    try {
+      await batch.commit();
+    } catch (error) {
+      // Catch the "Unsupported field value: undefined" error and
+      // provide a more helpful error message to the ROAR app developer.
+      if (error instanceof FirebaseError && error.message.toLowerCase().includes('unsupported field value: undefined')) {
         throw new Error(
-          'All ROAR trials saved to Firestore must have the following reserved keys: ' +
-            `${requiredTrialFields}.` +
-            'The current trial is missing the following required keys: ' +
-            `${requiredTrialFields.filter((key) => !(key in trialData))}.`,
+          'The computed or normed scores that you provided contained an undefined value. ' +
+            'Firestore does not support storing undefined values. ' +
+            'Please remove this value or convert it to ``null``.',
         );
       }
-
-      const trialRef = doc(collection(this.runRef, 'trials'));
-
-      return setDoc(trialRef, {
-        ...convertTrialToFirestore(trialData),
-        taskId: this.task.taskId,
-        ...(this.testData && { testData: true }),
-        ...(this.demoData && { demoData: true }),
-        serverTimestamp: serverTimestamp(),
-        createdAt: serverTimestamp(),
-        // Trial documents are never updated, but for standardization, adding this field. 
-        updatedAt: serverTimestamp(),
-      })
-        .then(async () => {
-          // Only update scores if the trial was a test or a practice response.
-          if (trialData.assessment_stage === 'test_response' || trialData.assessment_stage === 'practice_response') {
-            // Here we update the scores for this run. We create scores for each subtask in the task.
-            // E.g., ROAR-PA has three subtasks: FSM, LSM, and DEL. Each subtask has its own score.
-            // Conversely, ROAR-SWR has no subtasks. It's scores are stored in the 'total' score field.
-            // If no subtask is specified, the scores for the 'total' subtask will be updated.
-            const defaultSubtask = 'composite';
-            const subtask = (trialData.subtask || defaultSubtask) as string;
-
-            const stage = trialData.assessment_stage.split('_')[0] as 'test' | 'practice';
-
-            let scoreUpdate: ScoreUpdate = {};
-            if (subtask in this.scores.raw) {
-              // Then this subtask has already been added to this run.
-              // Simply update the block's scores.
-              this.scores.raw[subtask][stage] = {
-                thetaEstimate: castToTheta(trialData.thetaEstimate as ThetaValue),
-                thetaSE: castToTheta(trialData.thetaSE as ThetaValue),
-                numAttempted: (this.scores.raw[subtask][stage]?.numAttempted || 0) + 1,
-                // For the next two, use the unary + operator to convert the boolean value to 0 or 1.
-                numCorrect: (this.scores.raw[subtask][stage]?.numCorrect || 0) + +Boolean(trialData.correct),
-                numIncorrect: (this.scores.raw[subtask][stage]?.numIncorrect || 0) + +!trialData.correct,
-              };
-
-              // And populate the score update for Firestore.
-              scoreUpdate = {
-                [`scores.raw.${subtask}.${stage}.thetaEstimate`]: castToTheta(trialData.thetaEstimate as ThetaValue),
-                [`scores.raw.${subtask}.${stage}.thetaSE`]: castToTheta(trialData.thetaSE as ThetaValue),
-                [`scores.raw.${subtask}.${stage}.numAttempted`]: increment(1),
-                [`scores.raw.${subtask}.${stage}.numCorrect`]: trialData.correct ? increment(1) : undefined,
-                [`scores.raw.${subtask}.${stage}.numIncorrect`]: trialData.correct ? undefined : increment(1),
-              };
-
-              if (subtask !== defaultSubtask) {
-                this.scores.raw[defaultSubtask][stage] = {
-                  numAttempted: (this.scores.raw[defaultSubtask][stage]?.numAttempted || 0) + 1,
-                  // For the next two, use the unary + operator to convert the boolean value to 0 or 1.
-                  numCorrect: (this.scores.raw[defaultSubtask][stage]?.numCorrect || 0) + +Boolean(trialData.correct),
-                  numIncorrect: (this.scores.raw[defaultSubtask][stage]?.numIncorrect || 0) + +!trialData.correct,
-                  thetaEstimate: null,
-                  thetaSE: null,
-                };
-
-                scoreUpdate = {
-                  ...scoreUpdate,
-                  [`scores.raw.${defaultSubtask}.${stage}.numAttempted`]: increment(1),
-                  [`scores.raw.${defaultSubtask}.${stage}.numCorrect`]: trialData.correct ? increment(1) : undefined,
-                  [`scores.raw.${defaultSubtask}.${stage}.numIncorrect`]: trialData.correct ? undefined : increment(1),
-                };
-              }
-            } else {
-              // This is the first time this subtask has been added to this run.
-              // Initialize the subtask scores.
-              _set(this.scores.raw, [subtask, stage], {
-                thetaEstimate: castToTheta(trialData.thetaEstimate as ThetaValue),
-                thetaSE: castToTheta(trialData.thetaSE as ThetaValue),
-                numAttempted: 1,
-                numCorrect: trialData.correct ? 1 : 0,
-                numIncorrect: trialData.correct ? 0 : 1,
-              });
-
-              // And populate the score update for Firestore.
-              scoreUpdate = {
-                [`scores.raw.${subtask}.${stage}.thetaEstimate`]: castToTheta(trialData.thetaEstimate as ThetaValue),
-                [`scores.raw.${subtask}.${stage}.thetaSE`]: castToTheta(trialData.thetaSE as ThetaValue),
-                [`scores.raw.${subtask}.${stage}.numAttempted`]: 1,
-                [`scores.raw.${subtask}.${stage}.numCorrect`]: trialData.correct ? 1 : 0,
-                [`scores.raw.${subtask}.${stage}.numIncorrect`]: trialData.correct ? 0 : 1,
-              };
-
-              if (subtask !== defaultSubtask) {
-                _set(this.scores.raw, [defaultSubtask, stage], {
-                  numAttempted: 1,
-                  numCorrect: trialData.correct ? 1 : 0,
-                  numIncorrect: trialData.correct ? 0 : 1,
-                  thetaEstimate: null,
-                  thetaSE: null,
-                });
-
-                scoreUpdate = {
-                  ...scoreUpdate,
-                  [`scores.raw.${defaultSubtask}.${stage}.numAttempted`]: increment(1),
-                  [`scores.raw.${defaultSubtask}.${stage}.numCorrect`]: trialData.correct ? increment(1) : undefined,
-                  [`scores.raw.${defaultSubtask}.${stage}.numIncorrect`]: trialData.correct ? undefined : increment(1),
-                };
-              }
-            }
-
-            if (computedScoreCallback) {
-              // Use the user-provided callback to compute the computed scores.
-              this.scores.computed = await computedScoreCallback(this.scores.raw);
-            } else {
-              // If no computedScoreCallback is provided, we default to
-              // numCorrect - numIncorrect for each subtask.
-              this.scores.computed = _mapValues(this.scores.raw, (subtaskScores) => {
-                const numCorrect = subtaskScores.test?.numCorrect || 0;
-                const numIncorrect = subtaskScores.test?.numIncorrect || 0;
-                return numCorrect - numIncorrect;
-              });
-            }
-
-            // And use dot-object to convert the computed scores into dotted-key/value pairs.
-            // First nest the computed scores into `scores.computed` so that they get updated
-            // in the correct location.
-            const fullUpdatePath = {
-              scores: {
-                computed: this.scores.computed,
-              },
-            };
-            scoreUpdate = {
-              ...scoreUpdate,
-              ...dot.dot(fullUpdatePath),
-            };
-
-            return updateDoc(this.runRef, removeUndefined(scoreUpdate)).catch((error: FirebaseError) => {
-              // Catch the "Unsupported field value: undefined" error and
-              // provide a more helpful error message to the ROAR app developer.
-              if (error.message.toLowerCase().includes('unsupported field value: undefined')) {
-                throw new Error(
-                  'The computed or normed scores that you provided contained an undefined value. ' +
-                    'Firestore does not support storing undefined values. ' +
-                    'Please remove this value or convert it to ``null``.',
-                );
-              }
-              throw error;
-            });
-          }
-        })
-        .then(() => {
-          this.user.updateFirestoreTimestamp();
-        });
+      throw error;
     }
   }
 }

--- a/src/firestore/app/user.ts
+++ b/src/firestore/app/user.ts
@@ -213,15 +213,4 @@ export class RoarAppUser {
     return await updateDoc(this.userRef, removeUndefined(userData));
   }
 
-  /**
-   * Update the user's "lastUpdated" timestamp
-   * @method
-   * @async
-   */
-  async updateFirestoreTimestamp() {
-    this.checkUserExists();
-    return updateDoc(this.userRef, {
-      lastUpdated: serverTimestamp(),
-    });
-  }
 }

--- a/src/firestore/util.ts
+++ b/src/firestore/util.ts
@@ -264,6 +264,64 @@ export const mergeGameParams = (oldParams: { [key: string]: unknown }, newParams
   };
 };
 
+/**
+ * Retry an async operation with exponential backoff
+ * 
+ * @param operation - The async function to retry
+ * @param options - Retry configuration options
+ * @returns The result of the operation
+ * @throws The last error if all retries are exhausted
+ */
+export async function retryOperation<T>(
+  operation: () => Promise<T>,
+  options: {
+    maxRetries?: number;
+    initialDelayMs?: number;
+    maxDelayMs?: number;
+    backoffMultiplier?: number;
+    operationName?: string;
+  } = {},
+): Promise<T> {
+  const {
+    maxRetries = 3,
+    initialDelayMs = 1000,
+    maxDelayMs = 10000,
+    backoffMultiplier = 2,
+    operationName = 'operation',
+  } = options;
+
+  let lastError: Error | unknown;
+  
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      
+      if (attempt === maxRetries) {
+        // All retries exhausted
+        console.error(`${operationName} failed after ${maxRetries + 1} attempts:`, error);
+        throw error;
+      }
+      
+      // Calculate delay with exponential backoff
+      const delay = Math.min(initialDelayMs * Math.pow(backoffMultiplier, attempt), maxDelayMs);
+      
+      console.warn(
+        `${operationName} failed (attempt ${attempt + 1}/${maxRetries + 1}). ` +
+        `Retrying in ${delay}ms...`,
+        error
+      );
+      
+      // Wait before retrying
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+  
+  // This should never be reached, but TypeScript needs it
+  throw lastError;
+}
+
 export const crc32String = (inputString: string) => {
   const modulo = (a: number, b: number) => {
     return a - Math.floor(a / b) * b;


### PR DESCRIPTION
## Proposed changes
- Removing method to update the last updated field on the user document. It wasn't used anywhere (checked backend for any possible triggers / logic regarding this). 
- Updated operations in `startRun` and `writeTrials` to be atomic. 
- Throwing an error when `startRun` fails. 
- Adding a retry mechanism with exponential backoff for `startRun`. 
- Refactored the computed scores logic to be more readable. 

<!--
Describe your changes here.

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
