### PR TITLE
feat(): Fixing the variantref issue during the task start and fixing some emulator related bugs

### DIFF
--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -173,7 +173,7 @@ export class RoarRun {
     await this.user.checkUserExists();
 
     if (!this.task.variantRef) {
-      await this.task.toFirestore();
+      await this.task.setVariantRef();
     }
 
     const userDocSnap = await getDoc(this.user.userRef);
@@ -193,6 +193,7 @@ export class RoarRun {
       }
     }
 
+    // TODO: Check if grade and schoolLevel are needed for levante.
     const userDocData = _pick(userDocSnap.data(), [
       'grade',
       'assessmentPid',
@@ -203,6 +204,7 @@ export class RoarRun {
     ]);
 
     // Grab the testData and demoData flags from the user document.
+    // TODO: Check if testData and demoData are needed for levante.
     const { testData: isTestUser, demoData: isDemoUser } = userDocSnap.data();
 
     // Update testData and demoData for this instance based on the test/demo
@@ -243,6 +245,7 @@ export class RoarRun {
 
     const batch = writeBatch(this.user.db);
     batch.set(this.runRef, removeUndefined(runData));
+    // TODO: Check if this next update is needed for levante.
     batch.update(this.user.userRef, {
       tasks: arrayUnion(this.task.taskId),
       variants: arrayUnion(this.task.variantId),

--- a/src/firestore/app/task.ts
+++ b/src/firestore/app/task.ts
@@ -14,6 +14,7 @@ import {
   where,
   getDoc,
 } from 'firebase/firestore';
+import _isEqual from 'lodash/isEqual';
 import { mergeGameParams, removeUndefined, replaceValues } from '../util';
 
 export interface TaskVariantBase {
@@ -25,6 +26,7 @@ export interface TaskVariantBase {
   taskVersion?: string;
   gameConfig?: object;
   external?: boolean;
+  variantId?: string;
   variantName: string;
   variantParams: { [key: string]: unknown };
   registered?: boolean;
@@ -109,6 +111,7 @@ export class RoarTaskVariant {
     taskVersion = undefined,
     registered,
     external,
+    variantId = undefined,
     variantName,
     variantParams = {},
   }: TaskVariantBase) {
@@ -126,8 +129,8 @@ export class RoarTaskVariant {
     this.variantParams = variantParams;
     this.taskRef = doc(this.db, 'tasks', this.taskId);
     this.variantsCollectionRef = collection(this.taskRef, 'variants');
-    this.variantId = undefined;
-    this.variantRef = undefined;
+    this.variantId = variantId;
+    this.variantRef = variantId ? doc(this.variantsCollectionRef, variantId) : undefined;
   }
 
   /**
@@ -235,5 +238,28 @@ export class RoarTaskVariant {
 
     this.variantParams = merged;
     await this.toFirestore();
+  }
+
+  async setVariantRef() {
+    // If this is being called that means the variantId was not provided in the constructor
+    if (!this.variantParams) {
+      // If variant params are not then there is no way to determine the variant ref
+      throw new Error('Cannot set variant ref without variant params or variant id. Please provide one of them.');
+    }
+
+    // Query all the variants and do a deep match on the params field
+    const q = query(
+      this.variantsCollectionRef,
+      orderBy('updatedAt', 'desc'),
+    );
+    const querySnapshot = await getDocs(q);
+    // Go through the docs and match the this.variantParams with the params field in the doc
+    for (const docSnap of querySnapshot.docs) {
+      if (_isEqual(docSnap.data().params, this.variantParams)) {
+        this.variantId = docSnap.id;
+        break;
+      }
+    }
+    this.variantRef = doc(this.variantsCollectionRef, this.variantId);
   }
 }

--- a/src/firestore/util.ts
+++ b/src/firestore/util.ts
@@ -67,7 +67,7 @@ export const replaceValues = (
 export interface CommonFirebaseConfig {
   projectId: string;
   apiKey: string;
-  siteKey: string;
+  siteKey?: string;
   debugToken?: string;
 }
 

--- a/src/firestore/util.ts
+++ b/src/firestore/util.ts
@@ -1,4 +1,4 @@
-import { getApp, initializeApp } from 'firebase/app';
+import { type FirebaseOptions, getApp, initializeApp } from 'firebase/app';
 import {
   Auth,
   browserLocalPersistence,
@@ -89,6 +89,32 @@ export interface LiveFirebaseConfig extends CommonFirebaseConfig {
 
 export type FirebaseConfig = LiveFirebaseConfig | EmulatorFirebaseConfig;
 
+const EMULATOR_PROJECT_ID = 'demo-emulator';
+
+function isLiveFirebaseConfig(config: FirebaseConfig): config is LiveFirebaseConfig {
+  return 'authDomain' in config && typeof (config as LiveFirebaseConfig).authDomain === 'string';
+}
+
+/**
+ * Options for initializeApp when using local emulators. Keeps emulator projectId so
+ * Firestore/Auth emulators match, but passes through web client fields from the real
+ * project (authDomain, appId, etc.) so OAuth flows like Google sign-in work.
+ */
+function buildEmulatorFirebaseAppOptions(config: FirebaseConfig): FirebaseOptions {
+  const options: FirebaseOptions = {
+    projectId: EMULATOR_PROJECT_ID,
+    apiKey: config.apiKey,
+  };
+  if (isLiveFirebaseConfig(config)) {
+    options.authDomain = config.authDomain;
+    options.appId = config.appId;
+    options.storageBucket = config.storageBucket;
+    options.messagingSenderId = config.messagingSenderId;
+    if (config.measurementId) options.measurementId = config.measurementId;
+  }
+  return options;
+}
+
 export const safeInitializeApp = (config: LiveFirebaseConfig, name: string) => {
   try {
     const app = getApp(name);
@@ -164,7 +190,8 @@ export const initializeFirebaseProject = async (
 
   if (emulatorConfig) {
     console.log('Initializing Firebase emulator', emulatorConfig);
-    const app = initializeApp({ projectId: emulatorConfig ? 'demo-emulator' : config.projectId, apiKey: config.apiKey }, name);
+    const appOptions = buildEmulatorFirebaseAppOptions(config);
+    const app = initializeApp(appOptions, name);
     const auth = optionallyMarkRaw('auth', getAuth(app));
     const db = optionallyMarkRaw('db', getFirestore(app));
     const functions = optionallyMarkRaw('functions', getFunctions(app));


### PR DESCRIPTION
## Proposed changes
This PR takes care of couple things:
1. It does a better job of finding the variant ref during the initialization of the Tasks. It reads from the administration and not from the variant doc
2. If it does not find the variant, it does a similar path as before but in a better way (deep equal) as opposed to direct match using firestore
3. It does NOT write the new variant to the db, it throws an error if the variant is absolutely not found
4. Unrelated; it also fixes an issue with the emulator initialization that was preventing SSO testing on the emulator
<!--
Describe your changes here.

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
