### PR TITLE
Change the location of survey data for the child survey

### DIFF
--- a/src/firekit.ts
+++ b/src/firekit.ts
@@ -1117,7 +1117,7 @@ export class RoarFirekit {
     return _roarUid;
   }
 
-  async startAssessment(administrationId: string, taskId: string, taskVersion: string, targetUid?: string) {
+  async startAssessment(administrationId: string, taskId: string, taskVersion: string, trialContainer: 'runs' | 'surveyResponses' = 'runs', targetUid?: string) {
     this._verifyAuthentication();
 
     const uid = targetUid ?? this.roarUid ?? (await this.getRoarUid());
@@ -1163,6 +1163,7 @@ export class RoarFirekit {
         readOrgs: result.data.readOrgs,
         assignmentId: administrationId,
         taskInfo,
+        trialContainer,
       });
 
       return app;

--- a/src/firestore/app/appkit.ts
+++ b/src/firestore/app/appkit.ts
@@ -18,6 +18,7 @@ export interface AppkitInput {
   readOrgs?: OrgLists;
   assignmentId?: string;
   runId?: string;
+  trialContainer?: 'runs' | 'surveyResponses';
 }
 
 /**
@@ -40,6 +41,7 @@ export class RoarAppkit {
   private _authenticated: boolean;
   private _initialized: boolean;
   private _started: boolean;
+  private _trialContainer?: 'runs' | 'surveyResponses';
   /**
    * Create a RoarAppkit.
    *
@@ -60,6 +62,7 @@ export class RoarAppkit {
     readOrgs,
     assignmentId,
     runId,
+    trialContainer,
   }: AppkitInput) {
     if (!firebaseProject && !firebaseConfig) {
       throw new Error('You must provide either a firebaseProjectKit or firebaseConfig');
@@ -82,6 +85,7 @@ export class RoarAppkit {
     this._authenticated = false;
     this._initialized = false;
     this._started = false;
+    this._trialContainer = trialContainer;
   }
 
   private async _init() {
@@ -108,6 +112,7 @@ export class RoarAppkit {
       readOrgs: this._readOrgs,
       assignmentId: this._assignmentId,
       runId: this._runId,
+      trialContainer: this._trialContainer,
     });
     await this.user.init();
     this._initialized = true;

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -147,18 +147,14 @@ export class RoarRun {
     this.testData = testData;
     this.demoData = demoData;
 
-    if (runId) {
-      if (trialContainer === 'surveyResponses' && assignmentId) {
-        this.runRef = doc(this.user.userRef, trialContainer, runId, assignmentId);
-      } else {
-        this.runRef = doc(this.user.userRef, trialContainer, runId);
-      }
+    // {trialContainer}/{runId OR assignmentId}/trials
+    const trialContainerCollection = collection(this.user.userRef, trialContainer);
+    if (runId && trialContainer === 'runs') {
+      this.runRef = doc(trialContainerCollection, runId);
+    } else if (assignmentId && trialContainer === 'surveyResponses') {
+      this.runRef = doc(trialContainerCollection, assignmentId);
     } else {
-      if (trialContainer === 'surveyResponses' && assignmentId) {
-        this.runRef = doc(collection(this.user.userRef, trialContainer), assignmentId);
-      } else {
-        this.runRef = doc(collection(this.user.userRef, trialContainer));
-      }
+      this.runRef = doc(trialContainerCollection);
     }
 
     if (!this.task.taskRef) {

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -83,6 +83,7 @@ export interface RunInput {
   runId?: string;
   testData?: boolean;
   demoData?: boolean;
+  trialContainer?: 'runs' | 'surveyResponses';
 }
 
 interface ScoreUpdate {
@@ -136,6 +137,7 @@ export class RoarRun {
     runId,
     testData = false,
     demoData = false,
+    trialContainer = 'runs',
   }: RunInput) {
     this.user = user;
     this.task = task;
@@ -146,9 +148,17 @@ export class RoarRun {
     this.demoData = demoData;
 
     if (runId) {
-      this.runRef = doc(this.user.userRef, 'runs', runId);
+      if (trialContainer === 'surveyResponses' && assignmentId) {
+        this.runRef = doc(this.user.userRef, trialContainer, runId, assignmentId);
+      } else {
+        this.runRef = doc(this.user.userRef, trialContainer, runId);
+      }
     } else {
-      this.runRef = doc(collection(this.user.userRef, 'runs'));
+      if (trialContainer === 'surveyResponses' && assignmentId) {
+        this.runRef = doc(collection(this.user.userRef, trialContainer), assignmentId);
+      } else {
+        this.runRef = doc(collection(this.user.userRef, trialContainer));
+      }
     }
 
     if (!this.task.taskRef) {


### PR DESCRIPTION
## Proposed changes

<!--
Describe your changes here.

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

This PR adds a parameter that can be used to change the path that data is written to with the `writeTrial()` function - `{userId}/surveyResponses/{assignmentId}/trials` rather than `{userId}/runs/{runId}/trials`. This can be passed in from the dashboard side to change where the child survey data is saved (which is an exception since it needs to go to a different path than data from the rest of core tasks). It should retain its original functionality when nothing is passed in for the new param.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
