### PR TITLE
Remove all references to assessmentUid - part 2

### DIFF
--- a/src/firekit.ts
+++ b/src/firekit.ts
@@ -1137,7 +1137,7 @@ export class RoarFirekit {
         this.roarAppUserInfo = {
           db: this.admin!.db,
           roarUid: uid,
-          assessmentUid: this.admin!.user!.uid,
+          // assessmentUid: this.admin!.user!.uid,
           assessmentPid: result.data.assessmentPid,
           userType: result.data.userData.userType,
         };

--- a/src/firestore/app/user.ts
+++ b/src/firestore/app/user.ts
@@ -15,7 +15,7 @@ import { removeUndefined } from '../util';
 
 export interface UserInfo {
   roarUid?: string;
-  assessmentUid: string;
+  // assessmentUid: string;
   assessmentPid?: string;
   userType?: UserType;
   userMetadata?: { [key: string]: unknown };
@@ -54,7 +54,7 @@ interface FirestoreUserUpdate {
 export class RoarAppUser {
   db: Firestore;
   roarUid?: string;
-  assessmentUid: string;
+  // assessmentUid: string;
   assessmentPid?: string;
   userData?: DocumentData;
   userType: UserType;
@@ -70,7 +70,7 @@ export class RoarAppUser {
    * @param {object} input
    * @param {Firestore} input.db - The assessment Firestore instance to which this user's data will be written
    * @param {string} input.roarUid - The ROAR ID of the user
-   * @param {string} input.assessmentUid - The assessment firebase UID of the user
+   * @param {string} input.assessmentUid - The Firebase Auth UID of the user
    * @param {string} input.assessmentPid - The assessment PID of the user
    * @param {string} input.userType - The user type. Must be either 'admin', 'educator', 'student', 'caregiver', 'guest', or 'researcher.'
    * @param {object} input.userMetadata - An object containing additional user metadata
@@ -83,7 +83,7 @@ export class RoarAppUser {
   constructor({
     db,
     roarUid,
-    assessmentUid,
+    // assessmentUid,
     assessmentPid,
     userType = UserType.guest,
     userMetadata = {},
@@ -113,7 +113,7 @@ export class RoarAppUser {
     this.db = db;
     this.roarUid = roarUid;
     this.assessmentPid = assessmentPid;
-    this.assessmentUid = assessmentUid;
+    // this.assessmentUid = assessmentUid;
     this.userType = userType;
     this.userMetadata = userMetadata;
     this.testData = testData;
@@ -122,11 +122,11 @@ export class RoarAppUser {
     this.offlineTasks = offlineTasks;
     this.offlineAdministrations = offlineAdministrations;
 
-    if (userType === UserType.guest) {
-      this.userRef = doc(this.db, 'guests', this.assessmentUid);
-    } else {
-      this.userRef = doc(this.db, 'users', this.roarUid!);
-    }
+    // if (userType === UserType.guest) {
+    //   this.userRef = doc(this.db, 'guests', this.assessmentUid);
+    // } else {
+    this.userRef = doc(this.db, 'users', this.roarUid!);
+    // }
   }
 
   async init() {
@@ -150,7 +150,7 @@ export class RoarAppUser {
     this.userData = removeUndefined({
       ...this.userMetadata,
       assessmentPid: this.assessmentPid,
-      assessmentUid: this.assessmentUid,
+      // assessmentUid: this.assessmentUid,
       userType: this.userType,
     });
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -86,7 +86,7 @@ export interface UserDataInAdminDb extends DocumentData {
   userType: UserType;
   name?: Name;
   assessmentPid?: string;
-  assessmentUid?: string;
+  // assessmentUid?: string;
   assessmentsCompleted?: string[];
   assessmentsAssigned?: string[];
   assignmentsAssigned?: AssignmentDateMap;


### PR DESCRIPTION
## Proposed changes

The plan Cursor helped me build was to replace, instead of remove, the `assessmentUid`, so I decided to "soft-delete" it. If it doesn't break anything, we'll completely remove it.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
