### PR TITLE
createUsers error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@bdelab/roar-firekit": "^4.1.1",
-        "@levante-framework/levante-zod": "^1.2.0",
+        "@levante-framework/levante-zod": "^1.2.1",
         "ajv": "^8.17.1",
         "ajv-errors": "^3.0.0",
         "crc-32": "^1.2.2",
@@ -1645,9 +1645,9 @@
       }
     },
     "node_modules/@levante-framework/levante-zod": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@levante-framework/levante-zod/-/levante-zod-1.2.0.tgz",
-      "integrity": "sha512-EDxQHqQt8hkVhMImA+gbB7omhlO0EnBrcZiO7z1SQAXx1Oc3WhpD/GJfqhCfEWER6Ea0h+vFLjqZ7vLZ+xIrVg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@levante-framework/levante-zod/-/levante-zod-1.2.1.tgz",
+      "integrity": "sha512-vK2OYgfV+VTjOK/GplQa0noVynHrVtQSWzhQmN3DVhMWf1Xot4QOY+YFMF7XtZ80GSDVQfkyQ+5VnX1sI+qhuQ==",
       "license": "MIT",
       "dependencies": {
         "h3-js": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   ],
   "dependencies": {
     "@bdelab/roar-firekit": "^4.1.1",
-    "@levante-framework/levante-zod": "^1.2.0",
+    "@levante-framework/levante-zod": "^1.2.1",
     "ajv": "^8.17.1",
     "ajv-errors": "^3.0.0",
     "crc-32": "^1.2.2",

--- a/src/firekit.ts
+++ b/src/firekit.ts
@@ -1360,7 +1360,9 @@ export class RoarFirekit {
     });
   }
 
-  async createUsers(params: CreateUsersParams): Promise<
+  async createUsers(
+    params: CreateUsersParams,
+  ): Promise<
     | { code: 'success'; data: CreateUsersResult }
     | { code: 'app-error'; data: CreateUsersError }
     | { code: 'functions-error'; data: ParsedFunctionsError }
@@ -1375,20 +1377,16 @@ export class RoarFirekit {
     } catch (err: unknown) {
       if (err instanceof FirebaseError) {
         const createUsersError = CreateUsersErrorSchema.safeParse(err);
-        if (createUsersError.success)
-          return { code: 'app-error', data: createUsersError.data };
+        if (createUsersError.success) return { code: 'app-error', data: createUsersError.data };
 
         const functionsError = FunctionsErrorSchema.safeParse(err);
-        if (functionsError.success)
-          return { code: 'functions-error', data: functionsError.data };
+        if (functionsError.success) return { code: 'functions-error', data: functionsError.data };
 
         const firebaseError = FirebaseErrorSchema.safeParse(err);
-        if (firebaseError.success)
-          return { code: 'firebase-error', data: firebaseError.data };
+        if (firebaseError.success) return { code: 'firebase-error', data: firebaseError.data };
       }
 
-      if (err instanceof Error)
-        return { code: 'error', error: err };
+      if (err instanceof Error) return { code: 'error', error: err };
 
       return { code: 'error', error: new Error('Unexpected createUsers error', { cause: err }) };
     }

--- a/src/firekit.ts
+++ b/src/firekit.ts
@@ -1,5 +1,6 @@
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
+import { FirebaseError } from 'firebase/app';
 import {
   AuthError,
   EmailAuthProvider,
@@ -40,13 +41,17 @@ import {
 import { httpsCallable, HttpsCallableResult } from 'firebase/functions';
 
 import type {
+  CreateUsersError,
   CreateUsersParams,
   CreateUsersResult,
   GetSiteOverviewParams,
   GetSiteOverviewResult,
   GetSyncStatusParams,
   GetSyncStatusResult,
+  ParsedFirebaseError,
+  ParsedFunctionsError,
 } from '@levante-framework/levante-zod';
+import { CreateUsersErrorSchema, FirebaseErrorSchema, FunctionsErrorSchema } from '@levante-framework/levante-zod';
 
 import { AuthPersistence, MarkRawConfig, initializeFirebaseProject } from './firestore/util';
 import { FirebaseProject, Name, OrgLists, RoarConfig, StartTaskResult, UserDataInAdminDb } from './interfaces';
@@ -1355,11 +1360,38 @@ export class RoarFirekit {
     });
   }
 
-  async createUsers(params: CreateUsersParams): Promise<CreateUsersResult> {
-    this._verifyAuthentication();
-    const req = httpsCallable(this.admin!.functions, 'createUsers');
-    const res = await req(params);
-    return res.data as CreateUsersResult;
+  async createUsers(params: CreateUsersParams): Promise<
+    | { code: 'success'; data: CreateUsersResult }
+    | { code: 'app-error'; data: CreateUsersError }
+    | { code: 'functions-error'; data: ParsedFunctionsError }
+    | { code: 'firebase-error'; data: ParsedFirebaseError }
+    | { code: 'error'; error: Error }
+  > {
+    try {
+      this._verifyAuthentication();
+      const req = httpsCallable(this.admin!.functions, 'createUsers');
+      const res = await req(params);
+      return { code: 'success', data: res.data as CreateUsersResult };
+    } catch (err: unknown) {
+      if (err instanceof FirebaseError) {
+        const createUsersError = CreateUsersErrorSchema.safeParse(err);
+        if (createUsersError.success)
+          return { code: 'app-error', data: createUsersError.data };
+
+        const functionsError = FunctionsErrorSchema.safeParse(err);
+        if (functionsError.success)
+          return { code: 'functions-error', data: functionsError.data };
+
+        const firebaseError = FirebaseErrorSchema.safeParse(err);
+        if (firebaseError.success)
+          return { code: 'firebase-error', data: firebaseError.data };
+      }
+
+      if (err instanceof Error)
+        return { code: 'error', error: err };
+
+      return { code: 'error', error: new Error('Unexpected createUsers error', { cause: err }) };
+    }
   }
 
   async saveSurveyResponses(surveyResponses: LevanteSurveyResponses) {


### PR DESCRIPTION
## Proposed changes

- Bump `@levante-framework/levante-zod` to 1.2.1
- Update `createUsers` to explicitly handle errors and return a discriminated union instead of throwing

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)