### PR TITLE
Abstract explicit Firebase Functions result/error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@bdelab/roar-firekit": "^4.1.1",
-        "@levante-framework/levante-zod": "^1.2.2",
+        "@levante-framework/levante-zod": "^1.2.3",
         "ajv": "^8.17.1",
         "ajv-errors": "^3.0.0",
         "crc-32": "^1.2.2",
@@ -1645,9 +1645,9 @@
       }
     },
     "node_modules/@levante-framework/levante-zod": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@levante-framework/levante-zod/-/levante-zod-1.2.2.tgz",
-      "integrity": "sha512-y2B/dYtdFGpSGW73BXHg7s7xmRBkKn2WQYyM+qIX3OhRA0T0jK87VKoNuYxzZeAJW0HPIabgl+HLJjzWcNNVJQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@levante-framework/levante-zod/-/levante-zod-1.2.3.tgz",
+      "integrity": "sha512-LIGRYjbFAq4P9gKWx3WliIB0O12qMIsityCpSJ7Bb1tiWT0ugsI8GwCRHeFPTmmlRrE9ytrQC2QZ/VMzq/yzOA==",
       "license": "MIT",
       "dependencies": {
         "h3-js": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   ],
   "dependencies": {
     "@bdelab/roar-firekit": "^4.1.1",
-    "@levante-framework/levante-zod": "^1.2.2",
+    "@levante-framework/levante-zod": "^1.2.3",
     "ajv": "^8.17.1",
     "ajv-errors": "^3.0.0",
     "crc-32": "^1.2.2",

--- a/src/firebase-utils.ts
+++ b/src/firebase-utils.ts
@@ -1,0 +1,46 @@
+import { FirebaseError } from 'firebase/app';
+import { Functions, httpsCallable } from 'firebase/functions';
+import {
+  FirebaseErrorSchema,
+  FunctionsErrorSchema,
+  ParsedFirebaseError,
+  ParsedFunctionsError,
+  type ZodType,
+} from '@levante-framework/levante-zod';
+
+type CallableResult<TResult, TError> =
+  | { code: 'success'; data: TResult }
+  | { code: 'app-error'; data: TError }
+  | { code: 'functions-error'; data: ParsedFunctionsError }
+  | { code: 'firebase-error'; data: ParsedFirebaseError }
+  | { code: 'error'; data: Error };
+
+export async function callFirebaseFunction<TParams, TResult, TError>(
+  functions: Functions | undefined,
+  name: string,
+  params: TParams,
+  appErrorSchema: ZodType<TError>,
+): Promise<CallableResult<TResult, TError>> {
+  try {
+    if (!functions) throw new Error('Functions is not initialized');
+
+    const req = httpsCallable(functions, name);
+    const res = await req(params);
+
+    return { code: 'success', data: res.data as TResult };
+  } catch (err: unknown) {
+    if (err instanceof FirebaseError) {
+      const appError = appErrorSchema.safeParse(err);
+      if (appError.success) return { code: 'app-error', data: appError.data };
+
+      const functionsError = FunctionsErrorSchema.safeParse(err);
+      if (functionsError.success) return { code: 'functions-error', data: functionsError.data };
+
+      const firebaseError = FirebaseErrorSchema.safeParse(err);
+      if (firebaseError.success) return { code: 'firebase-error', data: firebaseError.data };
+    }
+
+    if (err instanceof Error) return { code: 'error', data: err };
+    return { code: 'error', data: new Error(`Unexpected ${name} error`, { cause: err }) };
+  }
+}

--- a/src/firekit.ts
+++ b/src/firekit.ts
@@ -1,6 +1,5 @@
 import _get from 'lodash/get';
 import _isEmpty from 'lodash/isEmpty';
-import { FirebaseError } from 'firebase/app';
 import {
   AuthError,
   EmailAuthProvider,
@@ -44,15 +43,20 @@ import type {
   CreateUsersError,
   CreateUsersParams,
   CreateUsersResult,
+  GetSiteOverviewError,
   GetSiteOverviewParams,
   GetSiteOverviewResult,
+  GetSyncStatusError,
   GetSyncStatusParams,
   GetSyncStatusResult,
-  ParsedFirebaseError,
-  ParsedFunctionsError,
 } from '@levante-framework/levante-zod';
-import { CreateUsersErrorSchema, FirebaseErrorSchema, FunctionsErrorSchema } from '@levante-framework/levante-zod';
+import {
+  CreateUsersErrorSchema,
+  GetSiteOverviewErrorSchema,
+  GetSyncStatusErrorSchema,
+} from '@levante-framework/levante-zod';
 
+import { callFirebaseFunction } from './firebase-utils';
 import { AuthPersistence, MarkRawConfig, initializeFirebaseProject } from './firestore/util';
 import { FirebaseProject, Name, OrgLists, RoarConfig, StartTaskResult, UserDataInAdminDb } from './interfaces';
 import { UserInput } from './firestore/app/user';
@@ -1277,20 +1281,6 @@ export class RoarFirekit {
     }
   }
 
-  async getSiteOverview(params: GetSiteOverviewParams): Promise<GetSiteOverviewResult> {
-    this._verifyAuthentication();
-    const req = httpsCallable(this.admin!.functions, 'getSiteOverview');
-    const res = await req(params);
-    return res.data as GetSiteOverviewResult;
-  }
-
-  async getSyncStatus(params: GetSyncStatusParams): Promise<GetSyncStatusResult> {
-    this._verifyAuthentication();
-    const req = httpsCallable(this.admin!.functions, 'getSyncStatus');
-    const res = await req(params);
-    return res.data as GetSyncStatusResult;
-  }
-
   /**
    * Upserts an organization in the database.
    *
@@ -1360,38 +1350,6 @@ export class RoarFirekit {
     });
   }
 
-  async createUsers(
-    params: CreateUsersParams,
-  ): Promise<
-    | { code: 'success'; data: CreateUsersResult }
-    | { code: 'app-error'; data: CreateUsersError }
-    | { code: 'functions-error'; data: ParsedFunctionsError }
-    | { code: 'firebase-error'; data: ParsedFirebaseError }
-    | { code: 'error'; error: Error }
-  > {
-    try {
-      this._verifyAuthentication();
-      const req = httpsCallable(this.admin!.functions, 'createUsers');
-      const res = await req(params);
-      return { code: 'success', data: res.data as CreateUsersResult };
-    } catch (err: unknown) {
-      if (err instanceof FirebaseError) {
-        const createUsersError = CreateUsersErrorSchema.safeParse(err);
-        if (createUsersError.success) return { code: 'app-error', data: createUsersError.data };
-
-        const functionsError = FunctionsErrorSchema.safeParse(err);
-        if (functionsError.success) return { code: 'functions-error', data: functionsError.data };
-
-        const firebaseError = FirebaseErrorSchema.safeParse(err);
-        if (firebaseError.success) return { code: 'firebase-error', data: firebaseError.data };
-      }
-
-      if (err instanceof Error) return { code: 'error', error: err };
-
-      return { code: 'error', error: new Error('Unexpected createUsers error', { cause: err }) };
-    }
-  }
-
   async saveSurveyResponses(surveyResponses: LevanteSurveyResponses) {
     this._verifyAuthentication();
 
@@ -1431,5 +1389,32 @@ export class RoarFirekit {
     const cloudEditUsers = httpsCallable(this.admin!.functions, 'editUsers');
     const result = await cloudEditUsers({ users });
     return result;
+  }
+
+  async createUsers(params: CreateUsersParams) {
+    return callFirebaseFunction<CreateUsersParams, CreateUsersResult, CreateUsersError>(
+      this.admin?.functions,
+      'createUsers',
+      params,
+      CreateUsersErrorSchema,
+    );
+  }
+
+  async getSiteOverview(params: GetSiteOverviewParams) {
+    return callFirebaseFunction<GetSiteOverviewParams, GetSiteOverviewResult, GetSiteOverviewError>(
+      this.admin?.functions,
+      'getSiteOverview',
+      params,
+      GetSiteOverviewErrorSchema,
+    );
+  }
+
+  async getSyncStatus(params: GetSyncStatusParams) {
+    return callFirebaseFunction<GetSyncStatusParams, GetSyncStatusResult, GetSyncStatusError>(
+      this.admin?.functions,
+      'getSyncStatus',
+      params,
+      GetSyncStatusErrorSchema,
+    );
   }
 }


### PR DESCRIPTION
## Proposed changes

- `src/firebase-utils.ts`
  - Add `callFirebaseFunction` to abstract explicit Firebase Functions result/error handling
- `src/firekit.ts`
  - Refactor `createUsers`, `getSiteOverview`, `getSyncStatus` to use `callFirebaseFunction`
- `package.json`, `package-lock.json`
  - Bump `@levante-framework/levante-zod` to 1.2.3

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)