### PR TITLE
Add function to update stopType field of run doc

### DIFF
--- a/src/firestore/app/appkit.ts
+++ b/src/firestore/app/appkit.ts
@@ -1,7 +1,7 @@
 import { onAuthStateChanged } from 'firebase/auth';
 import { updateDoc, arrayRemove, arrayUnion } from 'firebase/firestore';
 import { ref, getDownloadURL } from 'firebase/storage';
-import { ComputedScores, RawScores, RoarRun } from './run';
+import { ComputedScores, RawScores, RoarRun, StopReason } from './run';
 import { TaskVariantForAssessment, RoarTaskVariant } from './task';
 import { UserInfo, UserUpdateInput, RoarAppUser } from './user';
 import { FirebaseProject, OrgLists } from '../../interfaces';
@@ -338,9 +338,15 @@ export class RoarAppkit {
     return getDownloadURL(storageRef);
   }
 
-  async updateStopType(stopType: string) {
+  /**
+   * Persist the `stopReason` field to this run's Firestore document. Throws an
+   * error if the run has not been started yet or has already been aborted.
+   *
+   * @param stopReason - The reason the run was stopped (see {@link StopReason}).
+   */
+  async updateStopReason(stopReason: StopReason) {
     if (this._started) {
-      return await this.run!.addStopType(stopType);
+      await this.run!.updateStopReason(stopReason);
     } else {
       throw new Error('This run has not started. Use the startRun method first.');
     }

--- a/src/firestore/app/appkit.ts
+++ b/src/firestore/app/appkit.ts
@@ -340,7 +340,8 @@ export class RoarAppkit {
 
   /**
    * Persist the `stopReason` field to this run's Firestore document. Throws an
-   * error if the run has not been started yet or has already been aborted.
+   * error if the run has not been started yet, or if it has already been aborted
+   * and `stopReason` is anything other than `'taskAbort'`.
    *
    * @param stopReason - The reason the run was stopped (see {@link StopReason}).
    */

--- a/src/firestore/app/appkit.ts
+++ b/src/firestore/app/appkit.ts
@@ -337,4 +337,12 @@ export class RoarAppkit {
     const storageRef = ref(this.firebaseProject!.storage, filePath);
     return getDownloadURL(storageRef);
   }
+
+  async updateStopType(stopType: string) {
+    if (this._started) {
+      return await this.run!.addStopType(stopType);
+    } else {
+      throw new Error('This run has not started. Use the startRun method first.');
+    }
+  }
 }

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -558,7 +558,8 @@ export class RoarRun {
 
   /**
    * Persist the `stopReason` field to this run's Firestore document. Throws an
-   * error if the run has not been started yet or has already been aborted.
+   * error if the run has not been started yet, or if it has already been aborted
+   * and `stopReason` is anything other than `'taskAbort'`.
    *
    * @param stopReason - The reason the run was stopped (see {@link StopReason}).
    */

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -552,4 +552,14 @@ export class RoarRun {
       throw error;
     }
   }
+
+  async addStopType(stopType: string) {
+    if (!this.started) {
+      throw new Error('Run has not been started yet. Use the startRun method first.');
+    }
+
+    if (!this.aborted) {
+      return await updateDoc(this.runRef, { stopType: stopType });
+    }
+  }
 }

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -565,8 +565,10 @@ export class RoarRun {
   async updateStopReason(stopReason: StopReason) {
     if (!this.started) {
       throw new Error('Run has not been started yet. Use the startRun method first.');
-    } else if (this.aborted) {
-      throw new Error('Run has already been aborted.');
+    } else if (this.aborted && stopReason !== 'taskAbort') {
+      throw new Error(
+        'Run has already been aborted. Only "taskAbort" is allowed as a stop reason after a run has been aborted.',
+      );
     } else {
       await updateDoc(this.runRef, { stopReason });
     }

--- a/src/firestore/app/run.ts
+++ b/src/firestore/app/run.ts
@@ -98,6 +98,8 @@ const castToTheta = (value: ThetaValue) => {
   return value as number;
 };
 
+export type StopReason = 'earlyCompletion' | 'errorOut' | 'sufficientTrials' | 'taskAbort' | 'timeOut';
+
 /**
  * Class representing a ROAR run.
  *
@@ -554,13 +556,19 @@ export class RoarRun {
     }
   }
 
-  async addStopType(stopType: string) {
+  /**
+   * Persist the `stopReason` field to this run's Firestore document. Throws an
+   * error if the run has not been started yet or has already been aborted.
+   *
+   * @param stopReason - The reason the run was stopped (see {@link StopReason}).
+   */
+  async updateStopReason(stopReason: StopReason) {
     if (!this.started) {
       throw new Error('Run has not been started yet. Use the startRun method first.');
-    }
-
-    if (!this.aborted) {
-      return await updateDoc(this.runRef, { stopType: stopType });
+    } else if (this.aborted) {
+      throw new Error('Run has already been aborted.');
+    } else {
+      await updateDoc(this.runRef, { stopReason });
     }
   }
 }


### PR DESCRIPTION
## Proposed changes

<!--
Describe your changes here.

If it fixes a bug or resolves a feature request, be sure to link to that issue.

If appropriate, include images of the expected behavior or user experience.
You can drag and drop images into this text box.
-->

Adds a function to update the stopType field of the run document, which indicates why the task ended: taskAbort, errorOut, timeOut, sufficientTrials, or earlyCompletion. Goes with core-tasks PR: https://github.com/levante-framework/core-tasks/pull/492.

## Types of changes

What types of changes does this pull request introduce?

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that does not add functionality but makes code cleaner or more efficient)
- [ ] Tests (new or updated tests)
- [ ] Styles (changes to code styling)
- [ ] CI (continuous integration changes)
- [ ] Other (please describe below)

## Additional Notes

<!-- List any additional information that may be helpful to review or know about this change -->
